### PR TITLE
fix: move away from tiles to markdown as external links aren't workin…

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -1,19 +1,28 @@
 import { CompassConfig } from './compass';
 import { Service } from './types';
 
+enum UrlTypeToIcon {
+    CHAT_CHANNEL = '💬',
+    DOCUMENT = '📖',
+    DASHBOARD = '👀',
+    ON_CALL = '📲',
+    PROJECT = '🚀',
+    REPOSITORY = '🏡',
+    OTHER_LINK = '⭐',
+}
+
+
 export const defaultMarkdown = (config: CompassConfig, compassComponentUrl?: string, compassTeamUrl?: string) => {
   return `
 
 ## Links
 
-<Tiles>
-  ${compassComponentUrl ? `<Tile icon="RocketLaunchIcon" href="${compassComponentUrl}"  title="Compass Component" description="Open the Atlassian Compass Component in a new window" openWindow/>` : ''}
-  ${compassTeamUrl ? `<Tile icon="UserGroupIcon" href="${compassTeamUrl}"  title="Compass Team" description="Open Atlassian Compass Team in a new window" openWindow/>` : ''}
+* 🧭 [Compass Component](${compassComponentUrl})
+* 🪂 [Compass Team](${compassTeamUrl})
 ${config.links
   ?.filter((link) => link.name)
-  .map((link) => `<Tile href="${link.url}" openWindow title="${link.name}"/>`)
+  .map((link) => `* ${UrlTypeToIcon[link.type]} [${link.name}](${link.url})`)
   .join('\n')}
-</Tiles>
 
 ## Architecture diagram
 

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -7,19 +7,18 @@ import fs from 'fs/promises';
 // Fake eventcatalog config
 const eventCatalogConfig = {
   title: 'My EventCatalog',
+  homepageLink: 'https://bananas',
 };
 
 let catalogDir: string;
 
 const expectedMarkdown = `## Links
 
-<Tiles>
-  <Tile icon=\"RocketLaunchIcon\" href=\"https://compass.atlassian.com/component/00000000-0000-0000-0000-000000000000\"  title=\"Compass Component\" description=\"Open the Atlassian Compass Component in a new window\" openWindow/>
-  <Tile icon=\"UserGroupIcon\" href=\"https://compass.atlassian.com/people/team/00000000-0000-0000-0000-000000000000\"  title=\"Compass Team\" description=\"Open Atlassian Compass Team in a new window\" openWindow/>
-<Tile href=\"https://www.example.com/projects/myproject\" openWindow title=\"My Jira project\"/>
-<Tile href=\"https://www.example.com/dashboards/service-dashboard\" openWindow title=\"Service dashboard\"/>
-<Tile href=\"https://www.example.com/repos/my-service-repo\" openWindow title=\"Service repository\"/>
-</Tiles>
+* 🧭 [Compass Component](https://compass.atlassian.com/component/00000000-0000-0000-0000-000000000000)
+* 🪂 [Compass Team](https://compass.atlassian.com/people/team/00000000-0000-0000-0000-000000000000)
+* 🚀 [My Jira project](https://www.example.com/projects/myproject)
+* 👀 [Service dashboard](https://www.example.com/dashboards/service-dashboard)
+* 🏡 [Service repository](https://www.example.com/repos/my-service-repo)
 
 ## Architecture diagram
 


### PR DESCRIPTION
# What

Move away from tiles to markdown

# Why

Because external links aren't working on the build version of tiles

Closes #9 