### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -7,7 +9,6 @@ on:
   push:
     branches:
       - main
-
 jobs:
   build:
     name: Tests


### PR DESCRIPTION
Potential fix for [https://github.com/IsmaelMartinez/generator-atlassian-compass-event-catalog/security/code-scanning/3](https://github.com/IsmaelMartinez/generator-atlassian-compass-event-catalog/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to restrict the `GITHUB_TOKEN` permissions to `contents: read`. This is sufficient for the current workflow, which only checks out the repository and runs tests. No write permissions are required.

The `permissions` block will be added after the `name` field at the top of the workflow file. This ensures that all jobs in the workflow inherit these minimal permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
