### PR TITLE
feat: derive domains from Compass labels or custom fields

### DIFF
--- a/.changeset/domain-mapping-from-metadata.md
+++ b/.changeset/domain-mapping-from-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ismaelmartinez/generator-atlassian-compass-event-catalog': minor
+---
+
+Support deriving domains from Compass labels or custom fields. The `domain` option now accepts a mapping config (`{ from: 'label' | 'customField', key?, mapping, fallback? }`) in addition to the existing static `{ id, name, version }` form. Services resolve to domains per-component; each mapped domain is versioned independently and created lazily on first use.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ API mode credentials support `$ENV_VAR` syntax, so you can reference environment
 | `services`          | `ServiceOptions[]`                   | -          | YAML mode: array of local compass file paths                           |
 | `api`               | `ApiConfig`                          | -          | API mode: Compass GraphQL API connection config                        |
 | `compassUrl`        | `string`                             | (required) | Base URL for Compass component links                                   |
-| `domain`            | `{ id, name, version }`              | -          | Associate all services with a domain (created if it doesn't exist)     |
+| `domain`            | `DomainSpec \| DomainMapping`        | -          | Associate services with a domain (static, or derived from metadata)    |
 | `typeFilter`        | `string[]`                           | -          | Only process components matching these type IDs                        |
 | `nameFilter`        | `string[]`                           | -          | Only process components whose name matches one of these strings        |
 | `nameMapping`       | `Record<string, string>`             | -          | Map Compass component names to custom service IDs                      |
@@ -141,7 +141,42 @@ The generator continues processing when individual services fail (e.g. malformed
 
 ### Domain support
 
-When a `domain` option is provided, all generated services are associated with that domain. The domain is created automatically if it doesn't exist, and versioned if the version changes between runs.
+When a `domain` option is provided, generated services are associated with a domain. Domains are created automatically when first used, and versioned when their version string changes between runs.
+
+**Static domain** — all services go to the same domain:
+
+```js
+domain: { id: 'payments', name: 'Payments', version: '0.0.1' }
+```
+
+**Derived from a Compass label** — first matching label wins (case-sensitive):
+
+```js
+domain: {
+  from: 'label',
+  mapping: {
+    backend: { id: 'backend', name: 'Backend', version: '0.0.1' },
+    frontend: { id: 'frontend', name: 'Frontend', version: '0.0.1' },
+  },
+  fallback: { id: 'other', name: 'Other', version: '0.0.1' }, // optional; default is 'skip'
+}
+```
+
+**Derived from a custom field value**:
+
+```js
+domain: {
+  from: 'customField',
+  key: 'platform',
+  mapping: {
+    web: { id: 'web-platform', name: 'Web Platform', version: '0.0.1' },
+    mobile: { id: 'mobile-platform', name: 'Mobile Platform', version: '0.0.1' },
+  },
+  fallback: 'skip', // unmatched services get no domain association
+}
+```
+
+Each mapped domain is versioned independently — bumping one domain's `version` in config won't re-version the others.
 
 ## Security
 

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -1,5 +1,37 @@
 import utils from '@eventcatalog/sdk';
 import chalk from 'chalk';
+import type { CompassConfig } from './compass';
+import type { DomainOption, DomainSpec } from './types';
+
+function isDomainSpec(option: DomainOption): option is DomainSpec {
+  return 'id' in option && 'name' in option && 'version' in option;
+}
+
+export function resolveDomain(config: CompassConfig, option: DomainOption): DomainSpec | null {
+  if (isDomainSpec(option)) {
+    return option;
+  }
+
+  if (option.from === 'label') {
+    if (config.labels) {
+      for (const label of config.labels) {
+        if (option.mapping[label]) {
+          return option.mapping[label];
+        }
+      }
+    }
+  } else if (option.from === 'customField' && option.key) {
+    const field = config.customFields?.find((f) => f.name === option.key);
+    if (field && typeof field.value === 'string' && option.mapping[field.value]) {
+      return option.mapping[field.value];
+    }
+  }
+
+  if (option.fallback && option.fallback !== 'skip') {
+    return option.fallback;
+  }
+  return null;
+}
 
 export default class Domain {
   id: string;

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -15,14 +15,14 @@ export function resolveDomain(config: CompassConfig, option: DomainOption): Doma
   if (option.from === 'label') {
     if (config.labels) {
       for (const label of config.labels) {
-        if (option.mapping[label]) {
+        if (Object.prototype.hasOwnProperty.call(option.mapping, label)) {
           return option.mapping[label];
         }
       }
     }
   } else if (option.from === 'customField' && option.key) {
     const field = config.customFields?.find((f) => f.name === option.key);
-    if (field && typeof field.value === 'string' && option.mapping[field.value]) {
+    if (field && typeof field.value === 'string' && Object.prototype.hasOwnProperty.call(option.mapping, field.value)) {
       return option.mapping[field.value];
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,16 @@ export default async (_config: EventCatalogConfig, options: GeneratorProps) => {
   async function getDomainFor(compassConfig: CompassConfig): Promise<Domain | null> {
     if (!options.domain) return null;
     const spec = resolveDomain(compassConfig, options.domain);
-    if (!spec) return null;
+    if (!spec) {
+      if (options.debug) {
+        console.debug(chalk.magenta(` - No domain matched for ${compassConfig.name}, skipping domain association`));
+      }
+      return null;
+    }
+
+    if (options.debug) {
+      console.debug(chalk.magenta(` - Resolved domain for ${compassConfig.name}: ${spec.id} (v${spec.version})`));
+    }
 
     let instance = domainRegistry.get(spec.id);
     if (!instance) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { loadConfig, CompassConfig } from './compass';
 import { loadService, extractTeamId } from './service';
-import Domain from './domain';
+import Domain, { resolveDomain } from './domain';
 import { GeneratorProps, ResolvedDependency, ServiceIdStrategy, Service } from './types';
 export type { StructuredLink } from './types';
 import { GeneratorPropsSchema } from './validation';
@@ -111,19 +111,30 @@ export default async (_config: EventCatalogConfig, options: GeneratorProps) => {
   const newHashManifest: HashManifest = {};
   let skippedCount = 0;
 
-  let domain = null;
+  const domainRegistry = new Map<string, Domain>();
+  const processedDomainIds = new Set<string>();
 
-  if (options.domain) {
-    domain = new Domain(options.domain.id, options.domain.name, options.domain.version, projectDir);
-    if (dryRun) {
-      console.log(
-        chalk.yellow(
-          `\n[DRY RUN] Would create/update domain: ${options.domain.name} (id: ${options.domain.id}, v${options.domain.version})`
-        )
-      );
-    } else {
-      await domain.processDomain();
+  async function getDomainFor(compassConfig: CompassConfig): Promise<Domain | null> {
+    if (!options.domain) return null;
+    const spec = resolveDomain(compassConfig, options.domain);
+    if (!spec) return null;
+
+    let instance = domainRegistry.get(spec.id);
+    if (!instance) {
+      instance = new Domain(spec.id, spec.name, spec.version, projectDir);
+      domainRegistry.set(spec.id, instance);
     }
+
+    if (!processedDomainIds.has(spec.id)) {
+      processedDomainIds.add(spec.id);
+      if (dryRun) {
+        console.log(chalk.yellow(`\n[DRY RUN] Would create/update domain: ${spec.name} (id: ${spec.id}, v${spec.version})`));
+      } else {
+        await instance.processDomain();
+      }
+    }
+
+    return instance;
   }
 
   // First pass: build processable entries from either API or YAML mode
@@ -208,6 +219,7 @@ export default async (_config: EventCatalogConfig, options: GeneratorProps) => {
     try {
       console.log(chalk.blue(`\nProcessing component: ${compassConfig.name} (type: ${compassConfig.typeId || 'unknown'})`));
 
+      const domain = await getDomainFor(compassConfig);
       if (domain && !dryRun) {
         // Add the service to the domain
         await domain.addServiceToDomain(serviceId, version);

--- a/src/test/domain.test.ts
+++ b/src/test/domain.test.ts
@@ -1,0 +1,70 @@
+import { expect, it, describe } from 'vitest';
+import { resolveDomain } from '../domain';
+import type { CompassConfig } from '../compass';
+
+const base: CompassConfig = { name: 'svc' };
+
+describe('resolveDomain', () => {
+  it('returns the static spec unchanged', () => {
+    const spec = { id: 'd', name: 'D', version: '1.0.0' };
+    expect(resolveDomain(base, spec)).toBe(spec);
+  });
+
+  it('matches the first label present in the mapping', () => {
+    const target = { id: 'first', name: 'First', version: '1.0.0' };
+    const other = { id: 'second', name: 'Second', version: '1.0.0' };
+    const result = resolveDomain({ ...base, labels: ['foo', 'bar'] }, { from: 'label', mapping: { bar: other, foo: target } });
+    expect(result).toBe(target);
+  });
+
+  it('matches a custom field value', () => {
+    const target = { id: 'web', name: 'Web', version: '1.0.0' };
+    const result = resolveDomain(
+      { ...base, customFields: [{ type: 'text' as never, name: 'platform', value: 'web' }] },
+      { from: 'customField', key: 'platform', mapping: { web: target } }
+    );
+    expect(result).toBe(target);
+  });
+
+  it('returns the fallback when no label matches', () => {
+    const fallback = { id: 'fb', name: 'FB', version: '1.0.0' };
+    expect(resolveDomain({ ...base, labels: ['unmapped'] }, { from: 'label', mapping: {}, fallback })).toBe(fallback);
+  });
+
+  it('returns null when no match and fallback is "skip"', () => {
+    expect(resolveDomain({ ...base, labels: ['unmapped'] }, { from: 'label', mapping: {}, fallback: 'skip' })).toBeNull();
+  });
+
+  it('returns null when no match and fallback is omitted', () => {
+    expect(resolveDomain({ ...base, labels: ['unmapped'] }, { from: 'label', mapping: {} })).toBeNull();
+  });
+
+  it('ignores inherited Object.prototype properties on the mapping (labels)', () => {
+    // Regression: `{}.toString` is a function on Object.prototype; a label
+    // of "toString" must not resolve via prototype chain lookup.
+    expect(
+      resolveDomain(
+        { ...base, labels: ['toString', 'constructor', 'hasOwnProperty'] },
+        { from: 'label', mapping: {}, fallback: 'skip' }
+      )
+    ).toBeNull();
+  });
+
+  it('ignores inherited Object.prototype properties on the mapping (customField)', () => {
+    expect(
+      resolveDomain(
+        { ...base, customFields: [{ type: 'text' as never, name: 'k', value: 'toString' }] },
+        { from: 'customField', key: 'k', mapping: {}, fallback: 'skip' }
+      )
+    ).toBeNull();
+  });
+
+  it('ignores non-string custom field values', () => {
+    expect(
+      resolveDomain(
+        { ...base, customFields: [{ type: 'boolean' as never, name: 'k', value: true as never }] },
+        { from: 'customField', key: 'k', mapping: { true: { id: 'x', name: 'X', version: '1.0.0' } } }
+      )
+    ).toBeNull();
+  });
+});

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -380,6 +380,101 @@ describe('Atlassian Compass generator tests', () => {
       expect(never).toBeUndefined();
     });
 
+    it('routes multiple services to the same derived domain', async () => {
+      const { getDomain } = utils(catalogDir);
+
+      await plugin(eventCatalogConfig, {
+        services: [{ path: join(__dirname, 'my-service-compass.yml') }, { path: join(__dirname, 'my-application-compass.yml') }],
+        compassUrl: 'https://compass.atlassian.com',
+        domain: {
+          from: 'label',
+          mapping: {
+            baz: { id: 'shared', name: 'Shared', version: '0.0.1' },
+            frontend: { id: 'shared', name: 'Shared', version: '0.0.1' },
+          },
+        },
+      });
+
+      const shared = await getDomain('shared', '0.0.1');
+      expect(shared).toEqual(
+        expect.objectContaining({
+          id: 'shared',
+          services: expect.arrayContaining([
+            { id: 'my-service', version: '0.0.0' },
+            { id: 'my-application', version: '0.0.0' },
+          ]),
+        })
+      );
+      expect(shared.services).toHaveLength(2);
+    });
+
+    it('picks the first matching label when multiple labels are mapped', async () => {
+      const { getDomain } = utils(catalogDir);
+
+      // my-service-compass.yml labels are ['foo:bar', 'baz'] in that order.
+      // Both labels are in the mapping; the first label on the component wins.
+      await plugin(eventCatalogConfig, {
+        services: [{ path: join(__dirname, 'my-service-compass.yml') }],
+        compassUrl: 'https://compass.atlassian.com',
+        domain: {
+          from: 'label',
+          mapping: {
+            baz: { id: 'second', name: 'Second', version: '0.0.1' },
+            'foo:bar': { id: 'first', name: 'First', version: '0.0.1' },
+          },
+        },
+      });
+
+      const first = await getDomain('first', '0.0.1');
+      expect(first).toEqual(
+        expect.objectContaining({
+          id: 'first',
+          services: [{ id: 'my-service', version: '0.0.0' }],
+        })
+      );
+
+      const second = await getDomain('second', '0.0.1');
+      expect(second).toBeUndefined();
+    });
+
+    it('versions mapped domains independently across runs', async () => {
+      const { getDomain } = utils(catalogDir);
+
+      // First run — both domains at 0.0.1
+      await plugin(eventCatalogConfig, {
+        services: [{ path: join(__dirname, 'my-service-compass.yml') }, { path: join(__dirname, 'my-application-compass.yml') }],
+        compassUrl: 'https://compass.atlassian.com',
+        domain: {
+          from: 'label',
+          mapping: {
+            baz: { id: 'backend', name: 'Backend', version: '0.0.1' },
+            frontend: { id: 'frontend', name: 'Frontend', version: '0.0.1' },
+          },
+        },
+      });
+
+      // Second run — only bump `backend` to 0.0.2; `frontend` stays at 0.0.1
+      await plugin(eventCatalogConfig, {
+        services: [{ path: join(__dirname, 'my-service-compass.yml') }, { path: join(__dirname, 'my-application-compass.yml') }],
+        compassUrl: 'https://compass.atlassian.com',
+        domain: {
+          from: 'label',
+          mapping: {
+            baz: { id: 'backend', name: 'Backend', version: '0.0.2' },
+            frontend: { id: 'frontend', name: 'Frontend', version: '0.0.1' },
+          },
+        },
+      });
+
+      // Backend got bumped — old version archived, new version live.
+      expect(await getDomain('backend', '0.0.1')).toBeDefined();
+      expect(await getDomain('backend', '0.0.2')).toEqual(expect.objectContaining({ version: '0.0.2' }));
+
+      // Frontend stayed put — still at 0.0.1, no 0.0.2 version created.
+      expect(await getDomain('frontend', '0.0.1')).toEqual(expect.objectContaining({ version: '0.0.1' }));
+      expect(await getDomain('frontend', '0.0.2')).toBeUndefined();
+    });
+
     it('skips domain association when fallback is "skip" and no match', async () => {
       const { getDomain, getService } = utils(catalogDir);
 

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -293,6 +293,116 @@ describe('Atlassian Compass generator tests', () => {
     });
   });
 
+  describe('domain mapping from Compass metadata', () => {
+    it('routes services to different domains based on labels', async () => {
+      const { getDomain } = utils(catalogDir);
+
+      await plugin(eventCatalogConfig, {
+        services: [{ path: join(__dirname, 'my-service-compass.yml') }, { path: join(__dirname, 'my-application-compass.yml') }],
+        compassUrl: 'https://compass.atlassian.com',
+        domain: {
+          from: 'label',
+          mapping: {
+            baz: { id: 'backend', name: 'Backend', version: '0.0.1' },
+            frontend: { id: 'frontend', name: 'Frontend', version: '0.0.1' },
+          },
+        },
+      });
+
+      const backend = await getDomain('backend', '0.0.1');
+      expect(backend).toEqual(
+        expect.objectContaining({
+          id: 'backend',
+          name: 'Backend',
+          services: [{ id: 'my-service', version: '0.0.0' }],
+        })
+      );
+
+      const frontend = await getDomain('frontend', '0.0.1');
+      expect(frontend).toEqual(
+        expect.objectContaining({
+          id: 'frontend',
+          name: 'Frontend',
+          services: [{ id: 'my-application', version: '0.0.0' }],
+        })
+      );
+    });
+
+    it('routes a service to a domain based on a custom field value', async () => {
+      const { getDomain } = utils(catalogDir);
+
+      await plugin(eventCatalogConfig, {
+        services: [{ path: join(__dirname, 'my-service-compass.yml') }],
+        compassUrl: 'https://compass.atlassian.com',
+        domain: {
+          from: 'customField',
+          key: 'platform',
+          mapping: {
+            web: { id: 'web-platform', name: 'Web Platform', version: '0.0.1' },
+          },
+        },
+      });
+
+      const domain = await getDomain('web-platform', '0.0.1');
+      expect(domain).toEqual(
+        expect.objectContaining({
+          id: 'web-platform',
+          services: [{ id: 'my-service', version: '0.0.0' }],
+        })
+      );
+    });
+
+    it('uses fallback domain for unmatched services, skips when fallback is "skip"', async () => {
+      const { getDomain } = utils(catalogDir);
+
+      await plugin(eventCatalogConfig, {
+        services: [{ path: join(__dirname, 'my-service-compass.yml') }],
+        compassUrl: 'https://compass.atlassian.com',
+        domain: {
+          from: 'label',
+          mapping: {
+            nonexistent: { id: 'never', name: 'Never', version: '0.0.1' },
+          },
+          fallback: { id: 'catch-all', name: 'Catch All', version: '0.0.1' },
+        },
+      });
+
+      const fallback = await getDomain('catch-all', '0.0.1');
+      expect(fallback).toEqual(
+        expect.objectContaining({
+          id: 'catch-all',
+          services: [{ id: 'my-service', version: '0.0.0' }],
+        })
+      );
+
+      // Nothing was routed to the unmatched mapping entry, so it should not exist.
+      const never = await getDomain('never', '0.0.1');
+      expect(never).toBeUndefined();
+    });
+
+    it('skips domain association when fallback is "skip" and no match', async () => {
+      const { getDomain, getService } = utils(catalogDir);
+
+      await plugin(eventCatalogConfig, {
+        services: [{ path: join(__dirname, 'my-service-compass.yml') }],
+        compassUrl: 'https://compass.atlassian.com',
+        domain: {
+          from: 'label',
+          mapping: {
+            nonexistent: { id: 'never', name: 'Never', version: '0.0.1' },
+          },
+          fallback: 'skip',
+        },
+      });
+
+      const never = await getDomain('never', '0.0.1');
+      expect(never).toBeUndefined();
+
+      const service = await getService('my-service');
+      expect(service).toBeDefined();
+    });
+  });
+
   describe('all Compass component types', () => {
     it('processes APPLICATION type components', async () => {
       const { getService } = utils(catalogDir);

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,11 +50,20 @@ export type GeneratorProps = {
   incremental?: boolean;
 };
 
-export type DomainOption = {
+export type DomainSpec = {
   id: string;
   name: string;
   version: string;
 };
+
+export type DomainMapping = {
+  from: 'label' | 'customField';
+  key?: string;
+  mapping: Record<string, DomainSpec>;
+  fallback?: DomainSpec | 'skip';
+};
+
+export type DomainOption = DomainSpec | DomainMapping;
 
 export type ResolvedDependency = {
   id: string;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -6,11 +6,24 @@ const ServiceOptionsSchema = z.object({
   version: z.string().optional(),
 });
 
-const DomainOptionSchema = z.object({
+const DomainSpecSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
   version: z.string().min(1),
 });
+
+const DomainMappingSchema = z
+  .object({
+    from: z.enum(['label', 'customField']),
+    key: z.string().min(1).optional(),
+    mapping: z.record(z.string().min(1), DomainSpecSchema),
+    fallback: z.union([DomainSpecSchema, z.literal('skip')]).optional(),
+  })
+  .refine((data) => data.from !== 'customField' || !!data.key, {
+    message: '"key" is required when domain.from is "customField"',
+  });
+
+const DomainOptionSchema = z.union([DomainSpecSchema, DomainMappingSchema]);
 
 const ApiConfigSchema = z.object({
   cloudId: z.string().min(1, 'cloudId is required'),


### PR DESCRIPTION
The `domain` option now accepts a mapping form alongside the existing static `{ id, name, version }` form:

```js
domain: {
  from: 'label' | 'customField',
  key?: string,           // required for customField
  mapping: { [value]: DomainSpec },
  fallback?: DomainSpec | 'skip',   // default: 'skip'
}
```

Each mapped domain is versioned independently (bumping one entry's `version` does not cascade) and created lazily on first use. Unmatched services fall back to a catch-all domain or skip domain association entirely.

### Behavior change worth noting

Domain creation is now **lazy**: a domain is only created when at least one service is routed to it. Previously, a static `domain` was created unconditionally on every run. This is a silent semantic shift for users who relied on empty-domain creation, but it extends the dry-run fix from #209 consistently to normal runs (no more empty domains littering the catalog).

### Test coverage

- label routing (multiple services → different domains)
- customField routing
- fallback domain for unmatched services
- `fallback: 'skip'` behavior
- multiple services routed to the same derived domain (registry dedup)
- first matching label wins when multiple labels map
- per-domain independent versioning across runs

All 127 tests pass; lint and format clean.

https://claude.ai/code/session_01Touko1YVonaubxkMY4uypV