### PR TITLE
chore: deprecate plugin ahead of Atlassian Compass sunset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ismaelmartinez/generator-atlassian-compass-event-catalog
 
+## Unreleased
+
+### Deprecated
+
+- This package is now deprecated. Atlassian has announced that Compass is being sunset (end-of-sale 2026-05-13, renewals end 2026-12-31, support ends December 2027) and customers are being migrated to DX. Since this generator has no known production users, development is being wound down ahead of Atlassian's timeline. A runtime warning is now emitted whenever the generator runs. See the README for details.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Atlassian Compass EventCatalog Generator
 
+> [!WARNING]
+> **This project is deprecated and will not receive further updates.**
+>
+> Atlassian has [announced the end of Compass](https://www.atlassian.com/blog/announcements/the-next-chapter-for-compass). Compass reaches **end-of-sale on May 13, 2026**, renewals end **December 31, 2026**, and product support concludes in **December 2027**. Atlassian is directing customers to migrate to [DX](https://www.getdx.com/).
+>
+> Since this generator has no known production users, development is being wound down ahead of Atlassian's timeline. The package will remain published for existing installs, but no new features or non-critical fixes will be shipped. If you depend on this plugin, please pin the current version and plan a migration away from Compass.
+
 An [EventCatalog](https://eventcatalog.dev/) generator plugin that creates services from [Atlassian Compass](https://developer.atlassian.com/cloud/compass/config-as-code/structure-and-contents-of-a-compass-yml-file/) components. It supports two modes: reading local `compass.yml` files (YAML mode) or fetching components directly from the Compass GraphQL API (API mode).
 
 ## Installation

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,14 @@ type ProcessableEntry = {
 };
 
 export default async (_config: EventCatalogConfig, options: GeneratorProps) => {
+  console.warn(
+    chalk.yellow(
+      '[generator-atlassian-compass-event-catalog] DEPRECATED: Atlassian Compass is being sunset ' +
+        '(end-of-sale 2026-05-13, end-of-support 2027-12). This generator is no longer maintained. ' +
+        'See https://www.atlassian.com/blog/announcements/the-next-chapter-for-compass'
+    )
+  );
+
   // Validate configuration
   GeneratorPropsSchema.parse(options);
 


### PR DESCRIPTION
Atlassian has announced Compass end-of-sale on 2026-05-13, with renewals
ending 2026-12-31 and support ending December 2027. Since this generator
has no known production users, wind down development ahead of Atlassian's
timeline.

- README: add deprecation banner with Atlassian timeline and migration link
- src/index.ts: emit a runtime deprecation warning on every generator run
- CHANGELOG: document the deprecation under an "Unreleased" entry

https://claude.ai/code/session_01AJdhcSpUGzxbwm5H17Xvxk