### PR TITLE
fix(deps): bump js-yaml 4.2.0 -> 4.3.0 for GHSA-52cp-r559-cp3m

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 5.6.2
       js-yaml:
         specifier: ^4.1.1
-        version: 4.2.0
+        version: 4.3.0
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -1171,8 +1171,8 @@ packages:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1941,7 +1941,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -2874,7 +2874,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## What

Bumps `js-yaml` from **4.2.0** to **4.3.0** to clear the repo's one open high-severity Dependabot alert. The change is confined to `pnpm-lock.yaml` — `package.json` is untouched.

**Advisory:** [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / CVE-2026-59869 — "js-yaml: YAML merge-key chains can force quadratic CPU consumption". CVSS 7.5, high severity, runtime scope. Vulnerable range `>= 4.0.0, < 4.3.0`, first patched version `4.3.0`.

`js-yaml` is a direct runtime dependency here — `src/compass.ts` imports it as the YAML parser — so this is a plain dependency bump rather than a transitive override. The declared range `^4.1.1` already admits 4.3.0, so no manifest edit was necessary: the lockfile alone was holding the resolution at 4.2.0. The transitive copy under `@changesets/parse` deduped onto 4.3.0 in the same pass, so no vulnerable 4.x resolution remains anywhere in the tree. An unrelated `js-yaml@3.15.0` stays behind `gray-matter` and `read-yaml-file`, which sits outside this advisory's `>= 4.0.0` vulnerable range and is not in scope.

## Why not #249

Dependabot PR #249 proposes `js-yaml` 4.2.0 → **5.2.2**, a major bump well past the first patched version, and its Tests check is currently failing. This PR deliberately takes the smallest semver-safe hop that clears the advisory, staying inside major 4 and avoiding the API-break risk of a 4.x → 5.x migration. #249 is left open and untouched so the major upgrade can be considered separately on its own merits.

## Verification

Everything below was run with the repo-pinned pnpm 9.15.9 from the `packageManager` field, matching what CI resolves.

| Check | Result |
| --- | --- |
| Tests, this branch | 3 files, **136/136 passed**, 0 failed |
| Tests, base commit `322fe56` (baseline) | 3 files, **136/136 passed**, 0 failed |
| `pnpm install --frozen-lockfile` | passes (what CI runs) |
| `pnpm run build` | clean |
| `pnpm run lint` | clean |
| `pnpm run format:diff` | clean |

Post-change and baseline test results are identical, so there is no regression and no pre-existing failure being masked or misattributed.

## Impact

Clears the only open critical/high Dependabot alert on this repo, which unblocks the Gold health tier check "Zero critical/high security findings".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
