### PR TITLE
fix(deps): bump brace-expansion 5.0.7 -> 5.0.8 for GHSA-mh99-v99m-4gvg

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,9 +836,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2535,7 +2535,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3003,7 +3003,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 


### PR DESCRIPTION
Clears the one open high-severity Dependabot alert on this repo (alert #57), which is the last thing holding the repo below Gold tier on the security check.

## Advisory

- **GHSA-mh99-v99m-4gvg** — high, `brace-expansion`
- Vulnerable range: `<= 5.0.7`, first patched: `5.0.8`
- Manifest: `pnpm-lock.yaml`

## Before / after

| | Before | After |
|---|---|---|
| `brace-expansion` | 5.0.7 | 5.0.8 |

Only one resolved `brace-expansion` version existed in the lockfile, reached transitively through a single parent, `minimatch@10.2.5`, which declares `brace-expansion: ^5.0.5`. `minimatch@10.2.5` is in turn pulled in by `@eslint/config-array@0.23.5`, `@typescript-eslint/typescript-estree@8.65.0`, `eslint@10.7.0` and `glob@13.0.6`.

Because `^5.0.5` already admits 5.0.8, no manifest range needed widening and no dependency required a major bump. `brace-expansion@5.0.8` declares `balanced-match: ^4.0.2`, satisfied by the `balanced-match@4.0.4` already in the lockfile, so no new packages enter the tree. The published integrity hash and `engines` were checked against the registry rather than taken on trust; `engines: 20 || >=22` is satisfied by the Node 22 all CI workflows pin.

No `pnpm.overrides` entry was needed. Worth stating explicitly, since pnpm `overrides` do **not** reach auto-installed peer dependencies (unlike npm `overrides`) and this repo has `autoInstallPeers: true` — an override would have been an unreliable instrument here. It was unnecessary anyway: the parent's declared range already permits the patched version, so a plain resolution bump is both sufficient and less invasive.

## Lockfile provenance

The lockfile was written by **pnpm 9.15.9**, matching `packageManager: pnpm@9.15.9`. Version was confirmed as 9.15.9 before any resolution work. This matters: the global pnpm on the authoring machine is 10.33.2 and `manage-package-manager-versions` is disabled, so a pnpm 10 write would have silently reformatted the lockfile under pnpm 10 semantics and broken CI's `pnpm/action-setup@v6` + `--frozen-lockfile` step. `npx pnpm@9.15.9` was used purely as a launcher; npm was never used, which would have replaced the lockfile format outright.

## package.json: unchanged

`package.json` is deliberately untouched. `pnpm update brace-expansion --depth Infinity --lockfile-only` did, as a side effect, re-pin every dependency range in the manifest to its currently-resolved version (`^2.30.0` → `^2.31.1`, `^8.0.16` → `^8.1.5`, and so on). No resolved `version:` in the lockfile changed as a result — only the `specifier:` strings — so the rewrite was cosmetic re-pinning unrelated to this advisory. It was reverted, and the fix reduced to a minimal 5-line lockfile edit: the `packages:` entry (version key, integrity, engines), the `snapshots:` entry key, and `minimatch@10.2.5`'s dependency pointer.

Reconciling instead via `pnpm install --lockfile-only` was also rejected: it additionally deduped a pre-existing `@eslint-community/eslint-utils` 4.9.1/4.10.1 duplicate, which is unrelated cleanup and does not belong in a security patch.

## Verification

All four CI-gated scripts, run against pnpm 9.15.9. Baseline is the unmodified base commit (`1d51650`), measured before the change:

| Check | Baseline | After |
|---|---|---|
| `install --frozen-lockfile` | pass | pass |
| `test` (`vitest run`) | 3 files, 136/136 | 3 files, 136/136 |
| `build` (`tsup`) | pass | pass |
| `lint` (`eslint .`) | clean | clean |
| `format:diff` (`prettier --list-different`) | clean | clean |

`node_modules/.pnpm/brace-expansion@5.0.8` confirmed on disk after a clean `--frozen-lockfile` install, and no `5.0.7` reference remains anywhere in the lockfile.

## Remaining audit findings

`pnpm audit` reports **no known vulnerabilities** — zero findings, high or otherwise — across the full tree (381 dependencies) and again with `--prod`. Nothing outstanding. Audit is reported here independently of Dependabot because npm/pnpm audit data tends to lead Dependabot's alert feed.

Dependabot PRs #249 (js-yaml 5.x major) and #246 were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
